### PR TITLE
update central url from http to https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <repositories>
         <repository>
             <id>central</id>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
         </repository>
         <repository>
             <id>confluent</id>


### PR DESCRIPTION
Since January 15, 2020 maven central no longer supports HTTP, in favour of HTTPS. Consequently, spring repositories switched to HTTPS as well